### PR TITLE
[Docs/#3] swagger 설정

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -28,6 +28,9 @@ dependencies {
     // https://mvnrepository.com/artifact/org.postgresql/postgresql
     implementation("org.postgresql:postgresql")
 
+    // https://mvnrepository.com/artifact/org.springdoc/springdoc-openapi-starter-webmvc-ui
+    implementation("org.springdoc:springdoc-openapi-starter-webmvc-ui")
+
     compileOnly("org.projectlombok:lombok")
     annotationProcessor("org.projectlombok:lombok")
     testImplementation("org.springframework.boot:spring-boot-starter-test")


### PR DESCRIPTION
## 개요

- 협업을 위한 API 명세 자동 생성

## 설명 

- springdocs의 openapi 사용
  - swagger 최신 지원 패키지
- `http://localhost:8080/swagger-ui/index.html`에서 문서 확인

## 관련 이슈

main: #3 
related: #2 